### PR TITLE
Fix for the homonymic obsels bug (fixes #7)

### DIFF
--- a/lib/ktbs/engine/trace.py
+++ b/lib/ktbs/engine/trace.py
@@ -33,7 +33,7 @@ from .resource import KtbsPostableMixin, METADATA
 from .trace_obsels import ComputedTraceObsels, StoredTraceObsels
 from ..api.trace import AbstractTraceMixin, StoredTraceMixin, ComputedTraceMixin
 from ..namespace import KTBS, KTBS_NS_URI
-from ..utils import extend_api
+from ..utils import extend_api, check_new
 
 LOG = getLogger(__name__)
 
@@ -266,6 +266,13 @@ class StoredTrace(StoredTraceMixin, KtbsPostableMixin, AbstractTrace):
                 # start origin with a letter because if it starts with 4 digits,
                 # it will be misinterpreted for a year
                 new_graph.add((uri, KTBS.hasOrigin, origin))
+
+    def check_new(self, created):
+        """ I override :meth:`GraphPostableMixin.check_new`.
+
+        I check if the created resource exists in my obsel collection.
+        """
+        return check_new(self.obsel_collection.get_state(), created)
 
     def post_graph(self, graph, parameters=None,
                    _trust=False, _created=None, _rdf_type=None):

--- a/lib/rdfrest/mixins.py
+++ b/lib/rdfrest/mixins.py
@@ -247,6 +247,10 @@ class GraphPostableMixin(ILocalResource):
 
         return self._find_created_query(new_graph, query)
 
+    def check_new(self, created):
+        """Proxy to :func:`check_new` that can be overrided by children classes."""
+        return check_new(self.get_state(), created)
+
     def check_posted_graph(self, parameters, created, new_graph):
         """Check whether `new_graph` is acceptable to post on this resource.
 
@@ -270,7 +274,7 @@ class GraphPostableMixin(ILocalResource):
         # unused argument 'new_graph' #pylint: disable=W0613
         diag = Diagnosis("check_posted_graph")
         if isinstance(created, URIRef):
-            if not check_new(self.get_state(), created):
+            if not self.check_new(created):
                 diag.append("URI already in use <%s>" % created)
         return diag
 

--- a/utest/test_ktbs_engine.py
+++ b/utest/test_ktbs_engine.py
@@ -324,6 +324,29 @@ class TestKtbs(KtbsTestCase):
         new_tag = trace.obsel_collection.str_mon_tag
         eq_(old_tag, new_tag)
 
+    def test_post_homonymic_obsels(self):
+        """Check that it is impossible to post an obsel with an URI
+        that already exists in a trace."""
+        base = self.my_ktbs.create_base()
+        model = base.create_model()
+        otype1 = model.create_obsel_type("#MyObsel1")
+        otype2 = model.create_obsel_type("#MyObsel2")
+        trace = base.create_stored_trace(None, model, "1970-01-01T00:00:00Z",
+                                         "test homonymic obsels")
+
+        obsel = URIRef(trace.uri + 'obs')
+        graph1 = Graph()
+        graph1.add((obsel, KTBS.hasTrace, trace.uri))
+        graph1.add((obsel, RDF.type, otype1.uri))
+
+        graph2 = Graph()
+        graph2.add((obsel, KTBS.hasTrace, trace.uri))
+        graph2.add((obsel, RDF.type, otype2.uri))
+
+        created = trace.post_graph(graph1)
+        with assert_raises(InvalidDataError):
+            created_homonymic = trace.post_graph(graph2)
+
     def test_lineage(self):
         b = self.my_ktbs.create_base()
         model = b.create_model()


### PR DESCRIPTION
Previously we could post an obsel that had a URI already existing in the target trace.
This commit fixes this issue, we now correctly check the trace if the URI exists.

Also add the corresponding unit test.
